### PR TITLE
automatically deduce blockshape in tsqr function

### DIFF
--- a/rcnmf/tests/test_tsqr.py
+++ b/rcnmf/tests/test_tsqr.py
@@ -19,7 +19,7 @@ def run():
     blockshape = (200, 20)
     data = da.from_array(mat, blockshape=blockshape, name='A')
 
-    q, r = rcnmf.tsqr.tsqr(data, blockshape=blockshape)
+    q, r = rcnmf.tsqr.tsqr(data)
 
     dot_graph(q.dask, filename='q')
     dot_graph(r.dask, filename='r')

--- a/rcnmf/tests/test_tsqr2.py
+++ b/rcnmf/tests/test_tsqr2.py
@@ -17,7 +17,7 @@ data = into(da.Array, uri, blockshape=(100, 100))
 omega = da.random.standard_normal(size=(100, 20), blockshape=(100, 20))
 mat_h = data.dot(omega)
 
-q, r = rcnmf. tsqr.tsqr(mat_h, blockshape=(100, 20))
+q, r = rcnmf. tsqr.tsqr(mat_h)
 
 print data.shape
 print q.shape

--- a/rcnmf/tsqr.py
+++ b/rcnmf/tsqr.py
@@ -43,9 +43,14 @@ def tsqr(data, name=None):
     First and second tuple elements correspond to Q and R, of the
     QR decomposition.
     """
-    assert data.ndim == 2
-    assert len(set(data.blockdims[0])) == 1  # Uniform block size in rows
-    assert len(data.blockdims[1]) == 1  # Only one column block
+    if not (data.ndim == 2 and                    # Is a matrix
+            len(set(data.blockdims[0])) == 1 and  # Uniform block size in rows
+            len(data.blockdims[1]) == 1):         # Only one column block
+        raise ValueError(
+            "Input must have the following properites:\n"
+            "  1. Have two dimensions\n"
+            "  2. Have only one column of blocks\n"
+            "  3. Have uniformly sized row blocks")
     blockshape = (data.blockdims[0][0], data.blockdims[1][0])
     m, n = data.shape
 

--- a/rcnmf/tsqr.py
+++ b/rcnmf/tsqr.py
@@ -24,7 +24,7 @@ def _findnumblocks(shape, blockshape):
     return tuple(nb)
 
 
-def tsqr(data, blockshape=None, name=None):
+def tsqr(data, name=None):
     """
     Implementation of the direct TSQR, as presented in:
 
@@ -35,7 +35,6 @@ def tsqr(data, blockshape=None, name=None):
     http://arxiv.org/abs/1301.1071
 
     :param data: dask array object
-    :param blockshape: tuple
     Shape of the blocks that will be used to compute
     the blocked QR decomposition. We have the restrictions:
     - blockshape[1] == data.shape[1]
@@ -44,9 +43,11 @@ def tsqr(data, blockshape=None, name=None):
     First and second tuple elements correspond to Q and R, of the
     QR decomposition.
     """
-
+    assert data.ndim == 2
+    assert len(set(data.blockdims[0])) == 1  # Uniform block size in rows
+    assert len(data.blockdims[1]) == 1  # Only one column block
+    blockshape = (data.blockdims[0][0], data.blockdims[1][0])
     m, n = data.shape
-    assert (n == blockshape[1])
 
     prefix = name or next(names)
     prefix += '_'


### PR DESCRIPTION
This removes the need to take the blockshape as input to the `tsqr` function.  

I'm curious, is it feasible to implement this to support arrays without the same shape restrictions?  Not suggesting that we actually do this, mostly curious how hard it would be.
